### PR TITLE
Reward video is triggered automatically even when autoShow is set to …

### DIFF
--- a/src/ios/emiAdmobPlugin.m
+++ b/src/ios/emiAdmobPlugin.m
@@ -1445,7 +1445,10 @@ NSString *setKeyword = @"";
     NSDictionary *options = [command.arguments objectAtIndex:0];
     NSString *adUnitId = [options valueForKey:@"adUnitId"];
     BOOL autoShow = [[options valueForKey:@"autoShow"] boolValue];
-    auto_Show = autoShow;
+    //auto_Show = autoShow;
+    
+    __block BOOL shouldAutoShow = autoShow;
+    
     adFormat = 3;
     [self setAdRequest];
     if (adFormat == 3) {
@@ -1489,7 +1492,7 @@ NSString *setKeyword = @"";
                 
                 
 
-                if (auto_Show) {
+                if (shouldAutoShow) {
                     NSError *presentError = nil;
                     if ([self.rewardedAd canPresentFromRootViewController:self.viewController error:&presentError]) {
                         [self.rewardedAd presentFromRootViewController:self.viewController userDidEarnRewardHandler:^{


### PR DESCRIPTION

`cordova.plugins.emiAdmobPlugin.loadRewardedAd({ adUnitId: "ca-app-pub-xxx/xxx", autoShow: false }); `

This triggered automatically show the reward ad. This ensures the autoShow value used is only from that specific method call, and not accidentally inherited from previous state.

Please check this link
https://chatgpt.com/share/67ef801c-2280-8000-8155-41830be2c913