### PR TITLE
Auto show reward video ad & banner bottom show issue is fixed

### DIFF
--- a/src/ios/emiAdmobPlugin.m
+++ b/src/ios/emiAdmobPlugin.m
@@ -659,7 +659,25 @@ NSString *setKeyword = @"";
 
       GADAdSize siz = [self __AdSizeFromString:size];
       self.bannerView = [[GADBannerView alloc] initWithAdSize:siz];
-        
+
+
+    CGSize bannerSize = self.bannerView.bounds.size;
+    CGFloat screenWidth = parentView.bounds.size.width;
+    CGFloat screenHeight = parentView.bounds.size.height;
+
+    // Default to top-center
+    CGFloat originX = (screenWidth - bannerSize.width) / 2;
+    CGFloat originY = 0;
+
+    if ([setPosition isEqualToString:@"bottom-center"]) {
+        originY = screenHeight - bannerSize.height;
+    } else if ([setPosition isEqualToString:@"top-center"]) {
+        originY = 0;
+    }
+
+    self.bannerView.frame = CGRectMake(originX, originY, bannerSize.width, bannerSize.height);
+
+
       GADExtras *extras = [[GADExtras alloc] init];
 
       if (isCollapsible) {
@@ -706,7 +724,6 @@ NSString *setKeyword = @"";
         NSLog(@"[AdPlugin] Error in showBannerAd: %@", exception.reason);
     }
 }
-
 
 - (UIView*)findWebViewInView:(UIView*)view {
     if ([view isKindOfClass:NSClassFromString(@"WKWebView")] || [view isKindOfClass:NSClassFromString(@"UIWebView")]) {
@@ -1445,7 +1462,10 @@ NSString *setKeyword = @"";
     NSDictionary *options = [command.arguments objectAtIndex:0];
     NSString *adUnitId = [options valueForKey:@"adUnitId"];
     BOOL autoShow = [[options valueForKey:@"autoShow"] boolValue];
-    auto_Show = autoShow;
+    //auto_Show = autoShow;
+    
+    __block BOOL shouldAutoShow = autoShow;
+    
     adFormat = 3;
     [self setAdRequest];
     if (adFormat == 3) {
@@ -1489,7 +1509,7 @@ NSString *setKeyword = @"";
                 
                 
 
-                if (auto_Show) {
+                if (shouldAutoShow) {
                     NSError *presentError = nil;
                     if ([self.rewardedAd canPresentFromRootViewController:self.viewController error:&presentError]) {
                         [self.rewardedAd presentFromRootViewController:self.viewController userDidEarnRewardHandler:^{
@@ -1898,4 +1918,3 @@ NSString *setKeyword = @"";
               object:nil];
 }
 @end
-


### PR DESCRIPTION
1) Automatically the reward video is showing in the startup even  set autoShow: false. (This issue due to global variable, that means if we set any one autoshow:true (for banner) this will also showing)

2) Banner ad is showing in top area even set "bottom-center"

Referrences
1) https://chatgpt.com/share/67ef801c-2280-8000-8155-41830be2c913

2)https://chatgpt.com/share/67ef8a23-aa50-8000-89da-2e5c259c0b46