### PR TITLE
fix(android): Add mandatory AD_ID permission for Android 13+

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -33,8 +33,9 @@
       </feature>
     </config-file>
 
-    <config-file parent="/*" target="AndroidManifest.xml">
+ <config-file parent="/*" target="AndroidManifest.xml">
       <uses-permission android:name="android.permission.INTERNET" />
+      <uses-permission android:name="com.google.android.gms.permission.AD_ID" />
     </config-file>
 
     <config-file target="AndroidManifest.xml" parent="/manifest/application">


### PR DESCRIPTION
**What changed?**
    Added the com.google.android.gms.permission.AD_ID permission to the Android <config-file> in plugin.xml.
**Why is this necessary?**
    Google Play Console **now strictly requires apps targeting Android 13 (API level 33) and higher to explicitly declare this permission if they use the Advertising ID**. Because **AdMob relies on the Advertising ID**, developers using this plugin are currently being blocked from uploading their App Bundles (.aab) to the Play Store unless they manually hack their config.xml.
**Impact:**
    This prevents the Google Play Console rejection error and allows developers to safely declare "Yes" to using an Advertising ID without their builds failing.